### PR TITLE
remove c++ "namespace" keyword out from API

### DIFF
--- a/interfaces/airVantage/le_avdata.api
+++ b/interfaces/airVantage/le_avdata.api
@@ -432,7 +432,7 @@ FUNCTION le_result_t CreateResource
 //--------------------------------------------------------------------------------------------------
 FUNCTION le_result_t SetNamespace
 (
-    Namespace namespace
+    Namespace nameSpace
 );
 
 


### PR DESCRIPTION
I tested. And my C++ application could be compiled. Since I didn't wrote my C++ app, I just tested with assetData example. And that worked with this modification.
