### PR TITLE
Le ulpm

### DIFF
--- a/interfaces/le_ulpm.api
+++ b/interfaces/le_ulpm.api
@@ -96,6 +96,22 @@ ENUM GpioState
     GPIO_OFF,              ///< Gpio off.
 };
 
+//--------------------------------------------------------------------------------------------------
+/**
+ * Possible ULPS configurations to select before shutdown. Value 3 is skipped as it should not be
+ * used according to swimcu_pm documentation.
+ */
+//--------------------------------------------------------------------------------------------------
+ENUM ULPSConfiguration
+{
+    DISABLE_PSM = 0,             ///< Resquest to disable PSM
+    PSM_WITH_ULPM_FALLBACK = 1,  ///< Request enable PSM with ULPM fallback
+    POWER_OFF = 2,               ///< Request power off module
+    NO_REQUEST = 4,              ///< No request (Default value)
+    PSM_ONLY = 5,                ///< Request enable PSM only
+    ULPM_ONLY = 6,               ///< Request enable ULPM only
+};
+
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -194,6 +210,7 @@ FUNCTION le_result_t GetFirmwareVersion
  *      - LE_UNAVAILABLE if shutting is not possible now. Try again.
  *      - LE_NOT_PERMITTED if the process lacks sufficient permissions to perform a shutdown.
  *      - LE_UNSUPPORTED if the device lacks the ability to shutdown via ULPM.
+ *      - LE_BAD_PARAMETER if specified shutdown value is not valid.
  *      - LE_FAULT if there is a non-specific failure.
  */
 //--------------------------------------------------------------------------------------------------
@@ -213,3 +230,14 @@ FUNCTION le_result_t ShutDown();
  */
 //--------------------------------------------------------------------------------------------------
 FUNCTION le_result_t Reboot();
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set the Low Power Mode configuration to apply when le_ulpm_ShutDown is called.
+ */
+//--------------------------------------------------------------------------------------------------
+FUNCTION SetShutDownValue
+(
+    ULPSConfiguration ulpsConfig IN ///< Value used to configure ULPS.
+);


### PR DESCRIPTION
This patch adds a new method to le_ulpm API : **_le_ulpm_SetShutDownValue_**. This function allows the user to configure the Low Power mode before shutdown.
The possible values that can be selected are defined by an enum, based on the swimcu_pm documentation:
- **DISABLE_PSM** (Resquest to disable PSM)
- **PSM_WITH_ULPM_FALLBACK** (Request enable PSM with ULPM fallback)
- **POWER_OFF** (Request power off module)
- **NO_REQUEST** (No request (Default value))
- **PSM_ONLY** (Request enable PSM only)
- **ULPM_ONLY** (Request enable ULPM only)

This function changes the value written in `/sys/module/swimcu_pm/boot_source/enable` by _le_ulpm_ShutDown_ method. This is why this patch required to slightly modify _le_ulpm_ShutDown_ too.

The default behavior of _le_ulpm_ShutDown_ is not impacted, because if the user doesn't call _le_ulpm_SetShutDownValue_ beforehand, _le_ulpm_ShutDown_ will write **PSM_WITH_ULPM_FALLBACK** (1) into `/sys/module/swimcu_pm/boot_source/enable` as it was previously done.

This patch allow the user to have a better control over the Low Power modes used by the system.  
It makes it easier to disable PSM or ULPM without having to use AT commands in your Legato applications (as it was suggested in the workaround described in this [post](https://forum.legato.io/t/suddenly-unable-to-enter-ulpm/4717/9) to disable PSM).

Thank you for your time, have a great day !

BR
Paul Meis <paul.meis@wiifor.com>