### PR TITLE
Update apps.c to shutdown apps in opposite order as the startup one

### DIFF
--- a/framework/daemons/linux/supervisor/apps.c
+++ b/framework/daemons/linux/supervisor/apps.c
@@ -1363,8 +1363,8 @@ void apps_Shutdown
     // Deletes all inactive apps first.
     DeletesAllInactiveApp();
 
-    // Get the first app to stop.
-    le_dls_Link_t* appLinkPtr = le_dls_Peek(&ActiveAppsList);
+    // Get the first app to stop (taking from Tail to shutdown in opposite order as the startup one).
+    le_dls_Link_t* appLinkPtr = le_dls_PeekTail(&ActiveAppsList);
 
     if (appLinkPtr != NULL)
     {


### PR DESCRIPTION
The ActiveAppsList variable contains the applications that are started up, in the starting order. Usually the shutdown is better to be done in the opposite order to speed up resource free and deallocation (and avoid HardKills of applications that are stuck due to a shared resource being taken by an application still alive).

This is seen with modemDaemon legato service that gets HardKilled if an application is using its resources. Peeking from Tail solves the issue.