### PR TITLE
Update args.cpp to fix an error when the file is parsed with line len…

### DIFF
--- a/framework/tools/mkTools/commandLineInterpreter/args.cpp
+++ b/framework/tools/mkTools/commandLineInterpreter/args.cpp
@@ -859,7 +859,7 @@ bool MatchesSaved
     }
 
     int i;
-    char lineBuff[1024];
+    char lineBuff[8 * 1024];
 
     for (i = 0; i < buildParams.argc; i++)
     {


### PR DESCRIPTION
…gth greater than 1024

Opening the mktool_args with a line with more than 1024 characters, makes the parser fail with error bit set (the strcmp is not called, making mktool fail)

The file is saved in framework/tools/defTools/envVars.cpp with a lineBuff declared as 8 * 1024 bytes.